### PR TITLE
fix chrSkillHistory table creation

### DIFF
--- a/Database/Server/08-chrSkillHistory.sql
+++ b/Database/Server/08-chrSkillHistory.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS `chrSkillHistory`;
 
-CREATE TABLE `chrSkillhistory` (
+CREATE TABLE `chrSkillHistory` (
 	`characterID` INT(10) UNSIGNED NOT NULL,
 	`skillTypeID` INT(10) UNSIGNED NOT NULL,
 	`eventID` INT(10) NOT NULL,


### PR DESCRIPTION
Creating a new account fails on a brand new setup since the table cannot be found due to the uppercase `H`. Quick and easys fix for new setups.