### PR TITLE
fix: implement dummy tutorialSvc:GetContextHelp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.user
 Database/Oficial.sql
 Database/Server.sql
+logs/

--- a/Server/Node/Services/Tutorial/tutorialSvc.cs
+++ b/Server/Node/Services/Tutorial/tutorialSvc.cs
@@ -18,5 +18,10 @@ namespace Node.Services.Tutorial
                 "characterID", "tutorialID", "pageID", "eventTypeID"
             });
         }
+
+        public PyDataType GetContextHelp(CallInformation call)
+        {
+            return new PyList();
+        }
     }
 }


### PR DESCRIPTION
Logging into a new character fails due to a missing `GetContextHelp` method. There's no need to return anything but an empty list to properly login