### PR TITLE
Fix: convert input value to `utf8mb4_unicode_ci` when comparing.

### DIFF
--- a/Database/Procedures/053-cluResolveAddress.sql
+++ b/Database/Procedures/053-cluResolveAddress.sql
@@ -14,7 +14,7 @@ BEGIN
     # obtain the lock
     SELECT GET_LOCK (lockName, 0xFFFFFFFF) INTO errno;
     
-    SELECT nodeID INTO _nodeID FROM cluAddresses WHERE `type` = _type AND objectID = _objectID;
+    SELECT nodeID INTO _nodeID FROM cluAddresses WHERE `type` = CONVERT(_type USING utf8mb4) COLLATE utf8mb4_unicode_ci AND objectID = _objectID;
     
     IF _nodeID IS NULL THEN
         # find the new node to take care of the address

--- a/Server/EVESharp.Node/Services/Network/slash.cs
+++ b/Server/EVESharp.Node/Services/Network/slash.cs
@@ -65,6 +65,7 @@ public class slash : Service
         this.mCommands ["giveskills"] = this.GiveSkillCmd;
         this.mCommands ["giveskill"]  = this.GiveSkillCmd;
         this.mCommands ["giveisk"]    = this.GiveIskCmd;
+        this.mCommands ["load"]       = this.LoadCmd;
     }
 
     private string GetCommandListForClient ()
@@ -263,5 +264,33 @@ public class slash : Service
                 this.DogmaNotifications.QueueMultiEvent (character.ID, new OnSkillInjected ());
             }
         }
+    }
+
+    private void LoadCmd(string[] argv, ServiceCall call)
+    {
+        if (argv.Length < 3)
+            throw new SlashError("load takes at least two arguments");
+
+        int characterID = call.Session.CharacterID;
+
+        string target = argv[1].Trim('"', ' ');
+        int typeID = int.Parse(argv[2]);
+        int quantity = 1;
+
+        if (argv.Length > 3)
+            quantity = int.Parse(argv[3]);
+
+
+        if (target != "me" && target != characterID.ToString())
+            throw new SlashError("load only supports me for now");
+
+        call.Session.EnsureCharacterIsInStation();
+
+        // ensure the typeID exists
+        if (!Types.ContainsKey(typeID))
+            throw new SlashError("The specified typeID doesn't exist");
+
+        // create a new item with the correct locationID
+        DogmaItems.CreateItem<ItemEntity>(Types[typeID], characterID, call.Session.StationID, Flags.Hangar, quantity);
     }
 }


### PR DESCRIPTION
It seems that input value isn't collated with `utf8mb4_unicode_ci`. So I converted it.

The `load` command can be used by GM menus.